### PR TITLE
Don't panic for invalid op codes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -602,4 +602,13 @@ mod tests {
             },
         ])
     }
+
+    #[test]
+    fn invalid_op_code() {
+        for invalid_op_code in 250..=255 {
+            let input = [invalid_op_code];
+            let output = Instruction::parse(&input);
+            assert!(output.is_err())
+        }
+    }
 }


### PR DESCRIPTION
A DVI op code is an 8 byte unsigned integer in the range [0, 249]. The parser currently panics if it expects an op code but instead encounters a number in the range [250, 255]. This commit changes the parser to instead return an error in this case.

To make this maximally robust, we move all of the op code matching into a
single match statement. We can then statically enforce that an invalid op
code error will only be returned for these 6 values.